### PR TITLE
Move example sketch to appropriately named folder

### DIFF
--- a/examples/main/main.ino
+++ b/examples/main/main.ino
@@ -1,4 +1,4 @@
-#include "../multiThread.h"
+#include <multiThread.h>
 
 void fiveMinute(uint8_t b){
   Serial.print("another 5 minutes passed!")


### PR DESCRIPTION
The Arduino IDE requires the sketch folder name to match the filename of the primary sketch file. This change causes the example sketch to be accessible via the Arduino IDE's File > Examples > LIBRARYNAME menu after the library is installed.